### PR TITLE
Remove displayYearPicker and renderMonthTitle from input props

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,6 @@ setConfiguration({
          'October',
          'November',
          'December'
-    ],
-    previousButton: 'Previous', // Inner of previous button on YearPicker and MonthPicker
-    nextButton: 'Next' // Inner of next button on YearPicker and MonthPicker
+    ]
 });
 ```

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ setConfiguration({
          'October',
          'November',
          'December'
-    ]
+    ],
+    previousButton: 'Previous', // Inner of previous button on YearPicker and MonthPicker	
+    nextButton: 'Next' // Inner of next button on YearPicker and MonthPicker
 });
 ```

--- a/src/DatePicker.jsx
+++ b/src/DatePicker.jsx
@@ -16,7 +16,7 @@ class DatePicker extends React.Component {
         };
 
         this.calendarRef = React.createRef();
-        this.inputRef = React.createRef();
+        this.inputRef = props.inputRef || React.createRef();
     }
 
     componentDidUpdate(prevProps, prevState, snapshot) {
@@ -40,6 +40,7 @@ class DatePicker extends React.Component {
             year,
             onSelect,
             valueToDate,
+            inputRef,
             ...rest
         } = this.props;
         return <>

--- a/src/DatePicker.jsx
+++ b/src/DatePicker.jsx
@@ -16,7 +16,7 @@ class DatePicker extends React.Component {
         };
 
         this.calendarRef = React.createRef();
-        this.inputRef = props.inputRef || React.createRef();
+        this.inputRef = React.createRef();
     }
 
     componentDidUpdate(prevProps, prevState, snapshot) {
@@ -36,6 +36,8 @@ class DatePicker extends React.Component {
             visibleMonths,
             displayDayTitles,
             displayMonthPicker,
+            displayYearPicker,
+            renderMonthTitle,
             month,
             year,
             onSelect,

--- a/src/DatePicker.jsx
+++ b/src/DatePicker.jsx
@@ -42,7 +42,6 @@ class DatePicker extends React.Component {
             year,
             onSelect,
             valueToDate,
-            inputRef,
             ...rest
         } = this.props;
         return <>


### PR DESCRIPTION
remove the `React does not recognize the `renderMonthTitle` prop on a DOM element` errror